### PR TITLE
Update .travis.yml for Python 3.7 workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,14 @@ deploy:
     tags: true
 install: pip install -U tox-travis
 language: python
-python:
-- 3.5
-- 3.6
-- 3.7
+python: 
+  - 3.5
+  - 3.6
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 script: tox


### PR DESCRIPTION
There is an issue with Python 3.7 and Ubuntu 14.04 (the default for travis). This change will fix builds for Python 3.7. More info in the travis issue at https://github.com/travis-ci/travis-ci/issues/9815