### PR TITLE
Fix "AttributeError" for Python < 3.5.3 (missing "_get_running_loop()")

### DIFF
--- a/aiocontextvars.py
+++ b/aiocontextvars.py
@@ -30,6 +30,8 @@ if sys.version_info < (3, 7):
 
 
     def _get_state():
+        if not hasattr(asyncio, "_get_running_loop"):
+            return _state
         loop = asyncio._get_running_loop()
         if loop is None:
             return _state


### PR DESCRIPTION
Hi @fantix.

As discussed in #88, some earlier versions of Python are missing the `_get_running_loop()` used to implement the `contextvars` backport.

It seems complicated to properly fix it. What are your thoughts on just defaulting to `_state` (`threading.local()`) in that case?

Currently, using `aiocontextvars` with Python 3.5.2 (which is common on some Linux distributions) will cause an `AttributeError`. This "fix" would prevent errors in libraries relying on `aiocontextvars` for Python < 3.7.